### PR TITLE
Log rotate patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,12 +10,8 @@ This plugin uses the `docker-args` hook to inject the data volume argument. As s
 ## Installation
 
 ```sh
-# Create the directory to house the log files:
-sudo mkdir -p /var/log/dokku
-sudo chown dokku:dokku /var/log/dokku
-
-# Install the plugin:
 git clone https://github.com/sehrope/dokku-logging-supervisord.git /var/lib/dokku/plugins/logging-supervisord
+dokku plugins-install
 ```
 
 All future deployments will use this plugin to start all processes and all log output will be in `/var/log/dokku/$APP/`.

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ dokku plugins-install
 ```
 
 All future deployments will use this plugin to start all processes and all log output will be in `/var/log/dokku/$APP/`.
-Logs are rotated. You may customize logrotate file after deploy, check /etc/logrotate.d/dokku-app.d/<APP> file.
+Logs are rotated. You may customize logrotate file after deploy, check `/etc/logrotate.d/dokku-app.d/$APP` file.
 
 ## What it does
 
@@ -70,7 +70,7 @@ Adding the `SCALE` file is done by copying it into the container. This adds anot
 ## Logrotate
 
 This plugin create in directory "/etc/logrotate.d/dokku-app.d" logrotate config for each application.
-If application destroyed, config will be removed only if user don't change it (in dokku root, md5 checksum of config file stored).
+If application destroyed, config will be removed only if user don't change it (in app root directory, md5 checksum of config file stored).
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ dokku plugins-install
 ```
 
 All future deployments will use this plugin to start all processes and all log output will be in `/var/log/dokku/$APP/`.
+Logs are rotated. You may customize logrotate file after deploy, check /etc/logrotate.d/dokku-app.d/<APP> file.
 
 ## What it does
 
@@ -65,6 +66,11 @@ Rather than editing the file manually you can use the command:
 This will generate a new `SCALE` file and then deploy the app. An app rebuild will __not__ happen. It will just kill and restart your application.
 
 Adding the `SCALE` file is done by copying it into the container. This adds another layer to the container's AUFS. As there is a max number of layers you may need to occasionally run a rebuild (try `dokku rebuild myapp`) to rebase the container.
+
+## Logrotate
+
+This plugin create in directory "/etc/logrotate.d/dokku-app.d" logrotate config for each application.
+If application destroyed, config will be removed only if user don't change it (in dokku root, md5 checksum of config file stored).
 
 ## TODO
 

--- a/install
+++ b/install
@@ -16,7 +16,7 @@ chown dokku:dokku -R $LOGDIR
 
 # Allow dokku sudo command for creating logrotate configs.
 # Logrotate configs must have root ownerships and 644, what script "dokku-cfg-logrotate" do it.
-cat >> /etc/sudoers.d/dokku-plugin-logging-supervisord <<EOF
+cat > /etc/sudoers.d/dokku-plugin-logging-supervisord <<EOF
 # dokku-cfg-logrotate setup logrotate config files
 %dokku ALL=(ALL) NOPASSWD:$PLUGIN_DIR/lib/dokku-cfg-logrotate
 EOF

--- a/install
+++ b/install
@@ -17,13 +17,14 @@ chown dokku:dokku -R $LOGDIR
 # Allow dokku sudo command for creating logrotate configs.
 # Logrotate configs must have root ownerships and 644, what script "dokku-cfg-logrotate" do it.
 cat >> /etc/sudoers.d/dokku-plugin-logging-supervisord <<EOF
+# dokku-cfg-logrotate setup logrotate config files
 %dokku ALL=(ALL) NOPASSWD:$PLUGIN_DIR/lib/dokku-cfg-logrotate
 EOF
 
-# Copy logrotate includder.
+# Logrotate includder.
 LOGROT_DIR="/etc/logrotate.d/dokku-app.d"
 if [ ! -d $LOGROT_DIR ]; then
     mkdir $LOGROT_DIR
 fi
-cp $PLUGIN_DIR/lib/dokku-app-logrotate.conf /etc/logrotate.d/dokku-app
+echo "include $LOGROT_DIR" > /etc/logrotate.d/dokku-app
 chown root:root $LOGROT_DIR

--- a/install
+++ b/install
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+LOGDIR=/var/log/dokku
+
+if [ ! -d $LOGDIR ]; then
+    mkdir $LOGDIR
+fi
+
+chown dokku:dokku -R $LOGDIR

--- a/install
+++ b/install
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
-
+PLUGIN_DIR=$(dirname $0)
 LOGDIR=/var/log/dokku
 
 if [ ! -d $LOGDIR ]; then
@@ -9,3 +9,21 @@ if [ ! -d $LOGDIR ]; then
 fi
 
 chown dokku:dokku -R $LOGDIR
+
+# Logrotate.
+# Each post-release will create in directory
+# /etc/logrotate.d/dokku-app.d config file, if not exist it.
+
+# Allow dokku sudo command for creating logrotate configs.
+# Logrotate configs must have root ownerships and 644, what script "dokku-cfg-logrotate" do it.
+cat >> /etc/sudoers.d/dokku-plugin-logging-supervisord <<EOF
+%dokku ALL=(ALL) NOPASSWD:$PLUGIN_DIR/lib/dokku-cfg-logrotate
+EOF
+
+# Copy logrotate includder.
+LOGROT_DIR="/etc/logrotate.d/dokku-app.d"
+if [ ! -d $LOGROT_DIR ]; then
+    mkdir $LOGROT_DIR
+fi
+cp $PLUGIN_DIR/lib/dokku-app-logrotate.conf /etc/logrotate.d/dokku-app
+chown root:root $LOGROT_DIR

--- a/lib/dokku-app-logrotate.conf
+++ b/lib/dokku-app-logrotate.conf
@@ -1,1 +1,0 @@
-include /etc/logrotate.d/dokku-app.d

--- a/lib/dokku-app-logrotate.conf
+++ b/lib/dokku-app-logrotate.conf
@@ -1,0 +1,1 @@
+include /etc/logrotate.d/dokku-app.d

--- a/lib/dokku-cfg-logrotate
+++ b/lib/dokku-cfg-logrotate
@@ -21,7 +21,7 @@ function create_log_rotate() {
   LOGROT_FILE="$2"
   if [ ! -f "$LOGROT_FILE" ]; then
     echo "       Creating $LOGROT_FILE"
-    cat >> "$LOGROT_FILE" <<EOF
+    cat > "$LOGROT_FILE" <<EOF
 "/var/log/dokku/$APP/*log" {
   weekly
   su root

--- a/lib/dokku-cfg-logrotate
+++ b/lib/dokku-cfg-logrotate
@@ -3,10 +3,12 @@
 set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
 
 APP="$2"
+CHECKSUM_FILE="$3"
+LOGROT_FILE="/etc/logrotate.d/dokku-app.d/$APP"
 
-if [[ -z $APP ]]; then
+if [[ -z $APP || -z $CHECKSUM_FILE ]]; then
     cat <<EOF
-dokku-cfg-logrotate <create|remode> <app>
+dokku-cfg-logrotate <create|remode> <app> <checksumfilename>
 create     Create logrotate config for app if not exists.
 remove     Remove logrotate config if not changed by user.
 EOF
@@ -34,9 +36,21 @@ EOF
 
 case "$1" in
     create)
-        LOGROT_FILE="/etc/logrotate.d/dokku-app.d/$APP"
         create_log_rotate "$APP" "$LOGROT_FILE"
         chown root:root "$LOGROT_FILE"
         chmod 644 "$LOGROT_FILE"
+
+        md5sum "$LOGROT_FILE" > "$CHECKSUM_FILE"
+        ;;
+    remove)
+        if [[ -f "$CHECKSUM_FILE" && -f "$LOGROT_FILE" ]]; then
+            savedMD5=$(cat "$CHECKSUM_FILE")
+            currentMD5=$(md5sum "$LOGROT_FILE")
+            if [[ "$currentMD5" = "$savedMD5" ]]; then
+                rm "$LOGROT_FILE"
+                else
+                echo "       Keep user changed logrotate file $LOGROT_FILE"
+            fi
+        fi
         ;;
 esac

--- a/lib/dokku-cfg-logrotate
+++ b/lib/dokku-cfg-logrotate
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+APP="$2"
+
+if [[ -z $APP ]]; then
+    cat <<EOF
+dokku-cfg-logrotate <create|remode> <app>
+create     Create logrotate config for app if not exists.
+remove     Remove logrotate config if not changed by user.
+EOF
+    exit 1;
+fi
+
+# TODO: Maybe need strart some prerotate postrotate script inside docker running container?
+function create_log_rotate() {
+  APP="$1"
+  LOGROT_FILE="$2"
+  if [ ! -f "$LOGROT_FILE" ]; then
+    echo "       Creating $LOGROT_FILE"
+    cat >> "$LOGROT_FILE" <<EOF
+"/var/log/dokku/$APP/*log" {
+  weekly
+  su root
+  missingok
+  rotate 52
+  compress
+  sharedscripts
+}
+EOF
+  fi
+}
+
+case "$1" in
+    create)
+        LOGROT_FILE="/etc/logrotate.d/dokku-app.d/$APP"
+        create_log_rotate "$APP" "$LOGROT_FILE"
+        chown root:root "$LOGROT_FILE"
+        chmod 644 "$LOGROT_FILE"
+        ;;
+esac

--- a/lib/helpers
+++ b/lib/helpers
@@ -7,7 +7,7 @@ function copy_to_container() {
   SOURCE_FILE="$1"
   TARGET_FILE="$2"
   if [ ! -f "$SOURCE_FILE" ]; then
-    echo "Source file does not exist on host: $SOURCE_FILE"
+    echo "       Source file does not exist on host: $SOURCE_FILE"
     exit 1
   fi
   id=$(cat "$SOURCE_FILE" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > '$TARGET_FILE'")

--- a/lib/procfile-to-supervisord
+++ b/lib/procfile-to-supervisord
@@ -38,7 +38,7 @@ fi
 
 cat << EOF
 [program:${NAME}]
-command=/exec '${COMMAND}'
+command=/exec_svd '${COMMAND}'
 process_name:${PROCESS_NAME}
 numprocs=${NUM_PROCS}
 autostart=true

--- a/post-release
+++ b/post-release
@@ -22,18 +22,18 @@ else
   # Check for SCALE file in IMAGE
   SCALE_IN_IMAGE=$(docker run -i -t $IMAGE /exec ls SCALE > /dev/null 2>&1 ; echo $?)
   if [ "$SCALE_IN_IMAGE" -eq 0 ];then
-    echo "Found SCALE file in IMAGE"
+    echo "       Found SCALE file in IMAGE"
   else
-    echo "No SCALE file found; will use default of one process per entry in Procfile."
+    echo "       No SCALE file found; will use default of one process per entry in Procfile."
   fi
 fi
 
 echo "-----> Injecting Logging Supervisor ..."
 
 if docker run -a stdout -i $IMAGE /usr/bin/dpkg -s supervisor > /dev/null; then
-  echo "supervisor is already installed (skipping apt-get update/install)"
+  echo "       supervisor is already installed (skipping apt-get update/install)"
 else
-  echo "supervisor is not installed (will install via apt-get)"
+  echo "       supervisor is not installed (will install via apt-get)"
   id=$(docker run -i -a stdin $IMAGE /bin/bash -c "apt-get update && apt-get install -y supervisor && apt-get clean")
   test $(docker wait $id) -eq 0
   docker commit $id $IMAGE > /dev/null
@@ -43,3 +43,5 @@ fi
 id=$(cat "$PLUGIN_DIR/lib/runner" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /start")
 test $(docker wait $id) -eq 0
 docker commit $id $IMAGE > /dev/null
+
+sudo $PLUGIN_DIR/lib/dokku-cfg-logrotate create "$APP"

--- a/post-release
+++ b/post-release
@@ -44,4 +44,4 @@ id=$(cat "$PLUGIN_DIR/lib/runner" | docker run -i -a stdin $IMAGE /bin/bash -c "
 test $(docker wait $id) -eq 0
 docker commit $id $IMAGE > /dev/null
 
-sudo $PLUGIN_DIR/lib/dokku-cfg-logrotate create "$APP"
+sudo $PLUGIN_DIR/lib/dokku-cfg-logrotate create "$APP" "$DOKKU_ROOT/$APP/logrotate.md5"

--- a/post-release
+++ b/post-release
@@ -16,7 +16,7 @@ fi
 
 copy_to_container "$PLUGIN_DIR/lib/procfile-to-supervisord" /usr/local/bin/procfile-to-supervisord
 if [ -f "$SCALE_FILE" ]; then
-  echo "Found SCALE file: $SCALE_FILE"
+  echo "       Found SCALE file: $SCALE_FILE"
   copy_to_container "$SCALE_FILE" /app/SCALE
 else
   # Check for SCALE file in IMAGE
@@ -38,6 +38,12 @@ else
   test $(docker wait $id) -eq 0
   docker commit $id $IMAGE > /dev/null
 fi
+
+# Make copy of /exec for supervisor.
+# Original builstep use `ln -nsf /start /exec` that make fork supervisor again and again
+id=$(docker run -i -a stdin $IMAGE /bin/bash -c "cp /exec /exec_svd")
+test $(docker wait $id) -eq 0
+docker commit $id $IMAGE > /dev/null
 
 # Replace /start with our custom runner:
 id=$(cat "$PLUGIN_DIR/lib/runner" | docker run -i -a stdin $IMAGE /bin/bash -c "cat > /start")

--- a/pre-delete
+++ b/pre-delete
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eo pipefail; [[ $DOKKU_TRACE ]] && set -x
+
+APP="$1"
+PLUGIN_DIR=$(dirname $0)
+
+sudo $PLUGIN_DIR/lib/dokku-cfg-logrotate remove "$APP" "$DOKKU_ROOT/$APP/logrotate.md5"


### PR DESCRIPTION
- Add install hook, that create sudoers cfg for running "lib/dokku-cfg-logrotate" command which update /etc/logrotate.d/dokku-app.d/$APP rotate cfg (logrotate require these cfg be as root owner and 644).
- Update Readme for installing and logrotate
- Fix progrium/buildstep, supervisor command now /exec_svd, which is copy of /exec generated by "builder".
- Some indent of echo
